### PR TITLE
Extend tw-colors resolveTwcConfig for Fonts and Tailwind Colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "lodash.foreach": "^4.5.0",
         "rxjs": "~7.5.0",
         "tslib": "^2.3.0",
+        "validate-color": "^2.2.4",
         "zone.js": "~0.12.0"
       },
       "devDependencies": {
@@ -12184,6 +12185,11 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/validate-color": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/validate-color/-/validate-color-2.2.4.tgz",
+      "integrity": "sha512-Znolz+b6CwW6eBXYld7MFM3O7funcdyRfjKC/X9hqYV/0VcC5LB/L45mff7m3dIn9wdGdNOAQ/fybNuD5P/HDw=="
+    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -21745,6 +21751,11 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true
+    },
+    "validate-color": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/validate-color/-/validate-color-2.2.4.tgz",
+      "integrity": "sha512-Znolz+b6CwW6eBXYld7MFM3O7funcdyRfjKC/X9hqYV/0VcC5LB/L45mff7m3dIn9wdGdNOAQ/fybNuD5P/HDw=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lodash.foreach": "^4.5.0",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",
+    "validate-color": "^2.2.4",
     "zone.js": "~0.12.0"
   },
   "devDependencies": {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,21 +1,20 @@
 // From tw-colors: https://github.com/L-Blondy/tw-colors/blob/master/lib/index.ts
-
 import { flatten } from 'flat';
+import validateColor from 'validate-color';
 
-const plugin = require('tailwindcss/plugin');
-const forEach = require('lodash.foreach');
+const Color = require('color');
 
 const SCHEME = Symbol('color-scheme');
 const emptyConfig: TwcConfig = {};
 
-type NestedFonts = { [SCHEME]?: 'light' | 'dark' } & MaybeNested<
+type NestedStyles = { [SCHEME]?: 'light' | 'dark' } & MaybeNested<
   string,
   string
 >;
-type FlatFonts = { [SCHEME]?: 'light' | 'dark' } & Record<string, string>;
+type FlatStyle = { [SCHEME]?: 'light' | 'dark' } & Record<string, string>;
 type TwcObjectConfig<ThemeName extends string> = Record<
   ThemeName,
-  NestedFonts
+  NestedStyles
 >;
 type TwcFunctionConfig<ThemeName extends string> = (scheme: {
   light: typeof light;
@@ -29,13 +28,21 @@ type DefaultThemeObject<ThemeName = any> = {
 
 type ResolvedVariants = Array<{ name: string; definition: string[] }>;
 type ResolvedUtilities = { [selector: string]: Record<string, any> };
-type ResolvedFonts = {
-  [fontName: string]: string;
+type ResolvedStyle = {
+  [styleName: string]:
+    | string
+    | (({
+        opacityValue,
+        opacityVariable,
+      }: {
+        opacityValue: string;
+        opacityVariable: string;
+      }) => string);
 };
 type Resolved = {
   variants: ResolvedVariants;
   utilities: ResolvedUtilities;
-  fontFamily: ResolvedFonts;
+  styles: ResolvedStyle;
 };
 
 export type TwcConfig<ThemeName extends string = string> =
@@ -43,7 +50,7 @@ export type TwcConfig<ThemeName extends string = string> =
   | TwcFunctionConfig<ThemeName>;
 
 export interface TwcOptions<ThemeName extends string = string> {
-  produceCssVariable?: (fontName: string) => string;
+  produceCssVariable?: (styleName: string) => string;
   produceThemeClass?: (themeName: ThemeName) => string;
   produceThemeVariant?: (themeName: ThemeName) => string;
   defaultTheme?:
@@ -51,10 +58,11 @@ export interface TwcOptions<ThemeName extends string = string> {
     | (string & {})
     | DefaultThemeObject<ThemeName>;
   strict?: boolean;
+  styleType?: string;
 }
 
 /**
- * Resolves the variants, base and fonts to inject in the plugin
+ * Resolves the variants, base and styles to inject in the plugin
  * Library authors might use this function instead of the createThemes function
  */
 export const resolveTwcConfig = <ThemeName extends string>(
@@ -65,91 +73,134 @@ export const resolveTwcConfig = <ThemeName extends string>(
     produceThemeVariant = produceThemeClass,
     defaultTheme,
     strict = false,
+    styleType,
   }: TwcOptions<ThemeName> = {}
 ) => {
   const resolved: Resolved = {
     variants: [],
     utilities: {},
-    fontFamily: {},
+    styles: {},
   };
   const configObject =
-		typeof config === 'function' ? config({ dark, light }) : config;
-	// @ts-ignore forEach types fail to assign themeName
-	forEach(configObject, (fonts: NestedFonts, themeName: ThemeName) => {
-    const themeClassName = produceThemeClass(themeName);
-    const themeVariant = produceThemeVariant(themeName);
+    typeof config === 'function' ? config({ dark, light }) : config;
 
-    const flatFonts = flattenFonts(fonts);
-    // set the resolved.variants
-    resolved.variants.push({
-      name: themeVariant,
-      // tailwind will generate only the first matched definition
-      definition: [
-        generateVariantDefinitions(`.${themeClassName}`),
-        generateVariantDefinitions(`[data-theme='${themeName}']`),
-        generateRootVariantDefinitions(themeName, defaultTheme),
-      ].flat(),
-    });
+  // @ts-ignore forEach types fail to assign themeName
+  Object.entries(configObject).forEach(([themeName, styles]: [themeName: ThemeName, styles: NestedStyles]) => {
+      const themeClassName = produceThemeClass(themeName);
+      const themeVariant = produceThemeVariant(themeName);
 
-    const cssSelector = `.${themeClassName},[data-theme="${themeName}"]`;
-    // set the color-scheme css property
-    resolved.utilities[cssSelector] = fonts[SCHEME]
-      ? { 'color-scheme': fonts[SCHEME] }
-      : {};
+      const flatStyles = flattenStyles(styles);
+      // set the resolved.variants
+      resolved.variants.push({
+        name: themeVariant,
+        // tailwind will generate only the first matched definition
+        definition: [
+          generateVariantDefinitions(`.${themeClassName}`),
+          generateVariantDefinitions(`[data-theme='${themeName}']`),
+          generateRootVariantDefinitions(themeName, defaultTheme),
+        ].flat(),
+      });
 
-		forEach(flatFonts, (fontValue, fontName) => {
-      // this case was handled above
-      if ((fontName as any) === SCHEME) return;
-      const safeFontName = escapeChars(fontName, '/');
+      const cssSelector = `.${themeClassName},[data-theme="${themeName}"]`;
+      // set the color-scheme css property
+      resolved.utilities[cssSelector] = styles[SCHEME]
+        ? { 'color-scheme': styles[SCHEME] }
+        : {};
 
-      const twcFontVariable = produceCssVariable(safeFontName);
-      // add the css variables in "@layer utilities" for the hsl values
+      Object.entries(flatStyles).forEach(
+        ([styleName, styleValue]: [styleName: string, styleValue: string]) => {
+          // this case was handled above
+          if ((styleName as any) === SCHEME) return;
+          const safeStyleName = escapeChars(styleName, '/');
 
-			resolved.utilities[cssSelector][twcFontVariable] = fontValue;
-      addRootUtilities(resolved.utilities, {
-        key: twcFontVariable,
-        value: fontValue,
-        defaultTheme,
-        themeName,
-			});
-      // set the dynamic font in tailwind config theme.fonts
-			resolved.fontFamily[fontName] = `var(${twcFontVariable})`;
-    });
-  });
+					const twcStyleVariable = produceCssVariable(safeStyleName);
+					
+					if (styleType === 'colors' && validateColor(styleValue)) {
+            let [h, s, l, defaultAlphaValue]: HslaArray = [0, 0, 0, 1];
+            try {
+              [h, s, l, defaultAlphaValue] = toHslaArray(styleValue);
+            } catch (error: any) {
+              const message = `\r\nWarning - In theme "${themeName}" color "${styleName}". ${error.message}`;
 
-	return resolved;
-};
+              if (strict) {
+                throw new Error(message);
+              }
+              return console.error(message);
+            }
 
-export const createThemeFonts = <ThemeName extends string>(
-  config: TwcConfig<ThemeName> = emptyConfig,
-  options: TwcOptions<ThemeName> = {}
-) => {
-	const resolved = resolveTwcConfig(config, options);
+            const twcOpacityVariable = `${produceCssVariable(
+              safeStyleName
+            )}-opacity`;
 
-	return plugin(
-    ({ addUtilities, addVariant }) => {
-      // add the css variables to "@layer utilities" because:
-      // - The Base layer does not provide intellisense
-      // - The Components layer might get overriden by tailwind default fonts in case of name clash
-      addUtilities(resolved.utilities);
-      // add the theme as variant e.g. "theme-[name]:text-2xl"
-      resolved.variants.forEach(({ name, definition }) =>
-        addVariant(name, definition)
+            // add the css variables in "@layer utilities" for the hsl values
+            const hslValues = `${h} ${s}% ${l}%`;
+            resolved.utilities[cssSelector][twcStyleVariable] = hslValues;
+
+            addRootUtilities(resolved.utilities, {
+              key: twcStyleVariable,
+              value: hslValues,
+              defaultTheme,
+              themeName,
+            });
+
+            if (typeof defaultAlphaValue === 'number') {
+              // add the css variables in "@layer utilities" for the alpha
+              const alphaValue = defaultAlphaValue.toFixed(2);
+              resolved.utilities[cssSelector][twcOpacityVariable] = alphaValue;
+              addRootUtilities(resolved.utilities, {
+                key: twcOpacityVariable,
+                value: alphaValue,
+                defaultTheme,
+                themeName,
+              });
+            }
+
+            resolved.styles[styleName] = ({ opacityVariable, opacityValue }) => {
+              // if the opacity is set  with a slash (e.g. bg-primary/90), use the provided value
+              if (!isNaN(+opacityValue)) {
+                return `hsl(var(${twcStyleVariable}) / ${opacityValue})`;
+              }
+              // if no opacityValue was provided (=it is not parsable to a number),
+              // the twcOpacityVariable (opacity defined in the color definition rgb(0, 0, 0, 0.5))
+              // should have the priority over the tw class based opacity(e.g. "bg-opacity-90")
+              // This is how tailwind behaves as for v3.2.4
+              if (opacityVariable) {
+                return `hsl(var(${twcStyleVariable}) / var(${twcOpacityVariable}, var(${opacityVariable})))`;
+              }
+              return `hsl(var(${twcStyleVariable}) / var(${twcOpacityVariable}, 1))`;
+						};
+					} else if (styleType === 'colors') {
+            // const colorValue = 'colors.' + styleValue.toLowerCase().replace(' ', '.');
+            resolved.utilities[cssSelector][twcStyleVariable] = styleValue;
+
+            addRootUtilities(resolved.utilities, {
+              key: twcStyleVariable,
+              value: styleValue,
+              defaultTheme,
+              themeName,
+            });
+
+						resolved.styles[styleName] = `var(${twcStyleVariable})`;
+					}
+					
+          if (styleType !== 'colors') {
+            resolved.utilities[cssSelector][twcStyleVariable] = styleValue;
+
+            addRootUtilities(resolved.utilities, {
+              key: twcStyleVariable,
+              value: styleValue,
+              defaultTheme,
+              themeName,
+            });
+          }
+          // set the dynamic style in tailwind config theme.styles
+          if (styleType === 'fonts') resolved.styles[styleName] = `var(${twcStyleVariable})`;
+        }
       );
-    },
-    // extend the fonts config
-    {
-      theme: {
-        extend: {
-          // colors: {
-          //   'red-900': 'hsla(0, 0%, 0%, 1)',
-          // },
-          // @ts-ignore tailwind types are broken
-					fontFamily: resolved.fontFamily,
-        },
-      },
     }
   );
+
+  return resolved;
 };
 
 function escapeChars(str: string, ...chars: string[]) {
@@ -161,16 +212,20 @@ function escapeChars(str: string, ...chars: string[]) {
   return result;
 }
 
-function flattenFonts(fonts: NestedFonts) {
-  const flatFontsWithDEFAULT: FlatFonts = flatten(fonts, {
+function flattenStyles(style: NestedStyles) {
+  const flatStyleWithDEFAULT: FlatStyle = flatten(style, {
     safe: true,
     delimiter: '-',
   });
 
-  return Object.entries(flatFontsWithDEFAULT).reduce((acc, [key, value]) => {
+  return Object.entries(flatStyleWithDEFAULT).reduce((acc, [key, value]) => {
     acc[key.replace(/\-DEFAULT$/, '')] = value;
     return acc;
-  }, {} as FlatFonts);
+  }, {} as FlatStyle);
+}
+
+function toHslaArray(colorValue?: string) {
+  return Color(colorValue).hsl().round(1).array() as HslaArray;
 }
 
 function defaultProduceCssVariable(themeName: string) {
@@ -182,19 +237,19 @@ function defaultProduceThemeClass(themeName: string) {
 }
 
 function dark(
-  fonts: NestedFonts
+  styles: NestedStyles
 ): { [SCHEME]: 'dark' } & MaybeNested<string, string> {
   return {
-    ...fonts,
+    ...styles,
     [SCHEME]: 'dark',
   };
 }
 
 function light(
-  fonts: NestedFonts
+  styles: NestedStyles
 ): { [SCHEME]: 'light' } & MaybeNested<string, string> {
   return {
-    ...fonts,
+    ...styles,
     [SCHEME]: 'light',
   };
 }
@@ -287,3 +342,5 @@ interface MaybeNested<K extends keyof any = string, V extends string = string> {
 }
 
 type NoInfer<T> = [T][T extends any ? 0 : never];
+
+type HslaArray = [number, number, number, number | undefined];

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,133 @@
 /** @type {import('tailwindcss').Config} */
 const plugin = require("tailwindcss/plugin");
 const { createThemes } = require('tw-colors');
-import { createThemeFonts } from './src/utils/index';
+import { resolveTwcConfig } from './src/utils/index';
+
+const themeFontFamily = {
+	forest: {
+		body: '"Tenor Sans", sans-serif',
+    display: '"Merienda", cursive',
+  },
+  racer: {
+		body: "Montserrat",
+    display: "Anton",
+  },
+  "retro-diner": {
+		body: "Montserrat",
+    display: "Roboto Slab",
+  },
+};
+
+const tailwindColors = {
+	patchWRK: {
+		main: "white",
+		tertiary: "theme('colors.neutral.50')",
+		inactive: "theme('colors.blue.200')",
+		secondary: "theme('colors.slate.400')",
+		"accent-light": "theme('colors.slate.500')",
+		"trim-light": "theme('colors.slate.500')",
+		"accent-dark": "theme('colors.blue.700')",
+		primary: "theme('colors.blue.900')",
+		"trim-dark": "theme('colors.blue.900')",
+		info: "#0a0a0a",
+		success: "#22C55E",
+		error: "#F97316",
+		warning: "#DC2626",
+	},
+	nyias: {
+		main: "white",
+		tertiary: "theme('colors.neutral.50')",
+		inactive: "theme('colors.neutral.200')",
+		secondary: "theme('colors.red.400')",
+		"accent-light": "theme('colors.red.500')",
+		"trim-light": "theme('colors.red.500')",
+		"accent-dark": "theme('colors.neutral.700')",
+		primary: "theme('colors.neutral.900')",
+		"trim-dark": "theme('colors.neutral.900')",
+		info: "#0a0a0a",
+		success: "#22C55E",
+		error: "#F97316",
+		warning: "#DC2626",
+	},
+	dragons: {
+		main: "white",
+		tertiary: "theme('colors.neutral.50')",
+		inactive: "theme('colors.purple.200')",
+		secondary: "theme('colors.yellow.400')",
+		"accent-light": "theme('colors.yellow.500')",
+		"trim-light": "theme('colors.yellow.500')",
+		"accent-dark": "theme('colors.purple.700')",
+		primary: "theme('colors.purple.900')",
+		"trim-dark": "theme('colors.purple.900')",
+		info: "#0a0a0a",
+		success: "#22C55E",
+		error: "#F97316",
+		warning: "#DC2626",
+	},
+  grey: {
+    main: "white",
+    tertiary: "theme('colors.neutral.50')",
+    inactive: "theme('colors.neutral.100')",
+    secondary: "theme('colors.neutral.500')",
+    "accent-light": "theme('colors.neutral.600')",
+    "trim-light": "theme('colors.neutral.600')",
+    "accent-dark": "theme('colors.neutral.800')",
+    primary: "theme('colors.neutral.900')",
+    "trim-dark": "theme('colors.neutral.900')",
+    info: "#0a0a0a",
+    success: "#22C55E",
+    error: "#F97316",
+    warning: "#DC2626",
+  },
+  forest: {
+    main: "white",
+    tertiary: "theme('colors.amber.50')",
+    inactive: "theme('colors.amber.100')",
+    secondary: "theme('colors.amber.700')",
+    "accent-light": "theme('colors.amber.800')",
+    "trim-light": "theme('colors.amber.800')",
+    "accent-dark": "theme('colors.green.900')",
+    primary: "theme('colors.green.950')",
+    "trim-dark": "theme('colors.green.950')",
+    info: "#0a0a0a",
+    success: "#22C55E",
+    error: "#F97316",
+    warning: "#DC2626",
+	},
+	racer: {
+		main: "white",
+		tertiary: "theme('colors.neutral.50')",
+		inactive: "theme('colors.sky.100')",
+		secondary: "theme('colors.yellow.300')",
+		"accent-light": "theme('colors.red.700')",
+		"trim-light": "theme('colors.red.700')",
+		"accent-dark": "theme('colors.sky.500')",
+		primary: "theme('colors.sky.600')",
+		"trim-dark": "theme('colors.sky.600')",
+		info: "#0A0A0A",
+		success: "#22C55E",
+		error: "#F97316",
+		warning: "#DC2626",
+	},
+	"retro-diner": {
+		main: "white",
+		tertiary: "theme('colors.amber.50')",
+		inactive: "theme('colors.rose.200')",
+		secondary: "theme('colors.rose.500')",
+		"accent-light": "theme('colors.orange.400')",
+		"trim-light": "theme('colors.orange.400')",
+		"accent-dark": "theme('colors.teal.600')",
+		primary: "theme('colors.amber.950')",
+		"trim-dark": "theme('colors.amber.950')",
+		info: "#0A0A0A",
+		success: "#22C55E",
+		error: "#F97316",
+		warning: "#DC2626",
+	},
+};
+
+const resolvedColors = resolveTwcConfig(tailwindColors, { styleType: 'colors' })
+const resolvedFonts = resolveTwcConfig(themeFontFamily, { styleType: 'fonts' })
 
 module.exports = {
   content: ["./src/**/*.{html,js}"],
@@ -11,139 +137,36 @@ module.exports = {
     require("@tailwindcss/typography"),
     // require('tailwindcss/aspect-ratio'),
     // require('@tailwindcss/container-queries'),
-    createThemes(
-      {
-        patchWRK: {
-          main: "white",
-          tertiary: "#f9fafb",
-          inactive: "#bfdbfe",
-          secondary: "#94a3b8",
-          "accent-light": "#64748b",
-          "trim-light": "#64748b",
-          "accent-dark": "#1d4ed8",
-          primary: "#1e3a8a",
-          "trim-dark": "#1e3a8a",
-          info: "#0a0a0a",
-          success: "#22C55E",
-          error: "#F97316",
-          warning: "#DC2626",
-        },
-        nyias: {
-          main: "white",
-          tertiary: "#f9fafb",
-          inactive: "#e5e5e5",
-          secondary: "#f87171",
-          "accent-light": "#ef4444",
-          "trim-light": "#ef4444",
-          "accent-dark": "#404040",
-          primary: "#171717",
-          "trim-dark": "#171717",
-          info: "#0a0a0a",
-          success: "#22C55E",
-          error: "#F97316",
-          warning: "#DC2626",
-        },
-        dragons: {
-          main: "white",
-          tertiary: "#f9fafb",
-          inactive: "#e9d5ff",
-          secondary: "#facc15",
-          "accent-light": "#eab308",
-          "trim-light": "#eab308",
-          "accent-dark": "#7e22ce",
-          primary: "#581c87",
-          "trim-dark": "#581c87",
-          info: "#0a0a0a",
-          success: "#22C55E",
-          error: "#F97316",
-          warning: "#DC2626",
-        },
-        grey: {
-          main: "white",
-          tertiary: "#FAFAFA",
-          inactive: "#F5F5F5",
-          secondary: "#737373",
-          "accent-light": "#525252",
-          "trim-light": "#525252",
-          "accent-dark": "#262626",
-          primary: "#171717",
-          "trim-dark": "#171717",
-          info: "#0a0a0a",
-          success: "#22C55E",
-          error: "#F97316",
-          warning: "#DC2626",
-        },
-        forest: {
-          main: "white",
-          tertiary: "#FFFBEB",
-          inactive: "#FEF3C7",
-          secondary: "#B45309",
-          "accent-light": "#92400E",
-          "trim-light": "#92400E",
-          "accent-dark": "#14532D",
-          primary: "#052E16",
-          "trim-dark": "#052E16",
-          info: "#0A0A0A",
-          success: "#22C55E",
-          error: "#F97316",
-          warning: "#DC2626",
-        },
-        racer: {
-          main: "white",
-          tertiary: "#FAFAFA",
-          inactive: "#E0F2FE",
-          secondary: "#FDE047",
-          "accent-light": "#B91C1C",
-          "trim-light": "#B91C1C",
-          "accent-dark": "#0EA5E9",
-          primary: "#0284C7",
-          "trim-dark": "#0284C7",
-          info: "#0A0A0A",
-          success: "#22C55E",
-          error: "#F97316",
-          warning: "#DC2626",
-        },
-        "retro-diner": {
-          main: "white",
-          tertiary: "#FFFBEB",
-          inactive: "#FECDD3",
-          secondary: "#F43F5E",
-          "accent-light": "#FB923C",
-          "trim-light": "#FB923C",
-          "accent-dark": "#0D9488",
-          primary: "#451A03",
-          "trim-dark": "#451A03",
-          info: "#0A0A0A",
-          success: "#22C55E",
-          error: "#F97316",
-          warning: "#DC2626",
-        },
-      },
-      {
-        defaultTheme: "grey",
-        strict: true,
-      }
-    ),
-    createThemeFonts({
-      forest: {
-        body: '"Tenor Sans", sans-serif',
-        display: '"Merienda", cursive',
-      },
-      racer: {
-        body: "Montserrat",
-        display: "Anton",
-      },
-      "retro-diner": {
-        body: "Montserrat",
-        display: "Roboto Slab",
-      },
-    }),
+		// Based off of tw-colors plugin
+		plugin(
+			({ addUtilities, addVariant }) => {
+				// add the css variables to "@layer utilities" because:
+				// - The Base layer does not provide intellisense
+				// - The Components layer might get overriden by tailwind default styles in case of name clash
+				addUtilities(resolvedColors.utilities);
+				addUtilities(resolvedFonts.utilities);
+				// add the theme as variant e.g. "theme-[name]:text-2xl"
+				resolvedColors.variants.forEach(({ name, definition }) =>
+					addVariant(name, definition)
+				);
+			},
+			// extend the styles config
+			{
+				theme: {
+					extend: {
+						// @ts-ignore tailwind types are broken
+						colors: resolvedColors.styles,
+						fontFamily: resolvedFonts.styles,
+					},
+				},
+			}
+		),
   ],
 	theme: {
 		fontFamily: {
 			sans: ["Montserrat"]
 		},
-    extend: {
+		extend: {
       spacing: {
         "8xl": "96rem",
         "9xl": "128rem",


### PR DESCRIPTION
This will definitely break if you have a typo or use two different color types for the same key in different themes. I'm not sure how to prevent that. I think it's the way the utilities condense the same keys when looping to assign variable names.

**A Typo in the theme() will only break that theme.**
```css
dragons: {
    main: "white",
    tertiary: "theme('colors.neutral.50')",
    inactive: "theme('colors.purple.290')", //purple.290 isn't a tailwind color
    secondary: "theme('colors.yellow.400')",
    "accent-light": "theme('colors.yellow.500')",
    "trim-light": "theme('colors.yellow.500')",
    "accent-dark": "theme('colors.purple.700')",
    primary: "theme('colors.purple.900')",
    "trim-dark": "theme('colors.purple.900')",
    info: "#0a0a0a",
    success: "#22C55E",
    error: "#F97316",
    warning: "#DC2626",
},
```

**Primary will look for theme() instead of a hex. The grey theme will break.**
```css
grey: {
    main: "white",
    tertiary: "theme('colors.neutral.50')",
    inactive: "theme('colors.neutral.100')",
    secondary: "theme('colors.neutral.500')",
    "accent-light": "theme('colors.neutral.600')",
    "trim-light": "theme('colors.neutral.600')",
    "accent-dark": "theme('colors.neutral.800')",
    primary: "#FAFAFA", // If primary is a HEX here ...
    "trim-dark": "theme('colors.neutral.900')",
    info: "#0a0a0a",
    success: "#22C55E",
    error: "#F97316",
    warning: "#DC2626",
},
forest: {
    main: "white",
    tertiary: "theme('colors.amber.50')",
    inactive: "theme('colors.amber.100')",
    secondary: "theme('colors.amber.700')",
    "accent-light": "theme('colors.amber.800')",
    "trim-light": "theme('colors.amber.800')",
    "accent-dark": "theme('colors.green.900')",
    primary: "theme('colors.green.950')", // ... but a theme() here. Primary now expects theme()
    "trim-dark": "theme('colors.green.950')",
    info: "#0a0a0a",
    success: "#22C55E",
    error: "#F97316",
    warning: "#DC2626",
},
```